### PR TITLE
patch: specify to embed built files in package

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -18,6 +18,9 @@
     "build-fast": "node build.js --fast",
     "watch": "node build.js --watch"
   },
+  "files": [
+    "./built/**"
+  ],
   "license": "MIT",
   "devDependencies": {
     "esbuild": "^0.14.11",


### PR DESCRIPTION
The devicescript-compiler does not contain any built files.