### PR TITLE
patch: support for runtime_version

### DIFF
--- a/runtime/devicescript-vm/wasmpre.ts
+++ b/runtime/devicescript-vm/wasmpre.ts
@@ -167,6 +167,11 @@ export module Exts {
         )
     }
 
+    /**
+     * Verifies the format and version of the bytecode
+     * @param binary DeviceScript bytecode
+     * @returns error code, 0 if verificatino is successful
+     */
     export function devsVerify(binary: Uint8Array) {
         return copyToHeap(binary, ptr =>
             Module._jd_em_devs_verify(ptr, binary.length)


### PR DESCRIPTION
Pull in jacdac-c version

(note: because of the folder structure, updating jacdac-c does not automatically trigger a npm package update, so we somehow need to trigger a change under devicescript-vm)