### PR TITLE
fix: update cli info about build --watch

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -159,7 +159,6 @@ export async function compileBuf(buf: Buffer, options: BuildOptions = {}) {
 export interface BuildOptions {
     noVerify?: boolean
     outDir?: string
-    watch?: boolean
     stats?: boolean
     flag?: Record<string, boolean>
     cwd?: string
@@ -184,16 +183,12 @@ export async function build(file: string, options: BuildOptions & CmdOptions) {
     // log(`building ${file}`)
     ensureDirSync(options.outDir)
     await buildOnce(file, options)
-    // if (options.watch) await buildWatch(file, options)
 }
 
 async function buildOnce(file: string, options: BuildOptions & CmdOptions) {
-    const { watch, stats } = options
+    const { stats } = options
     const { success, binary, dbg } = await compileFile(file, options)
-    if (!success) {
-        if (watch) return
-        throw new CompilationError("compilation failed")
-    }
+    if (!success) throw new CompilationError("compilation failed")
 
     log(`bytecode: ${prettySize(binary.length)}`)
     if (stats) {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -45,13 +45,6 @@ export async function mainCli() {
 
     buildCommand("build", { isDefault: true })
         .description("build a DeviceScript file")
-        .option("-w, --watch", "watch file changes and rebuild automatically")
-        .option("--internet", "allow connections from non-localhost")
-        .option(
-            "--localhost",
-            "use localhost:8000 instead of the internet dashboard"
-        )
-        .option("-t, --tcp", "open native TCP socket at 8082")
         .arguments("[file.ts]")
         .action(build)
 

--- a/cli/src/devtools.ts
+++ b/cli/src/devtools.ts
@@ -327,7 +327,6 @@ async function rebuild(args: BuildReqArgs) {
     if (!opts.cwd) opts.cwd = dirname(args.filename)
     opts.noVerify = true
     opts.quiet = true
-    opts.watch = false
 
     const res = await compileFile(args.filename, opts)
     const binary = res.binary

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -55,7 +55,7 @@ const optionalFiles: Record<string, Object | string> = {
         scripts: {
             setup: "devicescript init",
             build: "devicescript build",
-            watch: "devicescript devtools --watch",
+            watch: "devicescript devtools main.ts",
             start: "yarn watch",
         },
     },

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -55,7 +55,7 @@ const optionalFiles: Record<string, Object | string> = {
         scripts: {
             setup: "devicescript init",
             build: "devicescript build",
-            watch: "devicescript build --watch",
+            watch: "devicescript devtools --watch",
             start: "yarn watch",
         },
     },
@@ -95,7 +95,7 @@ code .
 - start the watch build and developer tools server
 
 \`\`\`bash
-yarn start
+yarn watch
 \`\`\`
 
 -  navigate to devtools page (see terminal output) 

--- a/vscode/sampleprj/package.json
+++ b/vscode/sampleprj/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "setup": "devicescript init",
         "build": "devicescript build",
-        "watch": "devicescript build --watch",
-        "start": "yarn setup && yarn watch"
+        "watch": "devicescript devtools --watch",
+        "start": "yarn watch"
     }
 }

--- a/vscode/sampleprj/package.json
+++ b/vscode/sampleprj/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "setup": "devicescript init",
         "build": "devicescript build",
-        "watch": "devicescript devtools --watch",
+        "watch": "devicescript devtools main.ts",
         "start": "yarn watch"
     }
 }

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -30,7 +30,6 @@ npm install -g -u @devicescript/cli
 The command tool is named `devicescript` or `devsc` for short.
 The full list of options for each command is available through the CLI by running `devsc help <command>`.
 
-
 ## devsc init
 
 The `init` commands creates or updates the necessary files to get syntax completion
@@ -79,20 +78,28 @@ devsc build
 
 ### --stats
 
-The ``--stats`` flag enables printing additional debugging information about code size,
+The `--stats` flag enables printing additional debugging information about code size,
 and other useful metrics.
 
 ```bash
 devsc build --stats
 ```
 
-### --watch
+## devsc devtools
 
-To automatically rebuild your program based on file changes,
-add `--watch`.
+The `devtools` command launches the developer tool server, without trying to build a project.
 
 ```bash
-devsc build --watch
+devsc devtools
+```
+
+### build watch
+
+To automatically rebuild your program based on file changes,
+add the file name.
+
+```bash
+devsc devtools main.ts
 ```
 
 When the build is run in watch mode, it also opens a developer tool web server that allows
@@ -111,23 +118,6 @@ stateDiagram-v2
     cli --> browser: bytecode
     browser --> sim
     browser --> dev: WebSerial, WebUsb, ...
-```
-
-
-#### --internet
-
-To access the developer tools outside localhost, add `--internet`
-
-```bash
-devsc build --watch --internet
-```
-
-## devsc devtools
-
-The `devtools` command launches the developer tool server, without trying to build a project.
-
-```bash
-devsc devtools
 ```
 
 #### --internet

--- a/website/docs/getting-started/code.md
+++ b/website/docs/getting-started/code.md
@@ -73,7 +73,7 @@ Assuming `main.ts` is the root file of your application,
 launch a compilation task in watch mode using this command.
 
 ```bash
-devsc build --watch
+devsc devtools main.ts
 ```
 
 The command line task will also start a local web server that will send the compiled bytecode

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -143,8 +143,8 @@ async function createConfig() {
                                     scripts: {
                                         "setup": "devicescript init",
                                         "build": "devicescript build",
-                                        "watch": "devicescript build --watch",
-                                        start: "yarn setup && yarn watch",
+                                        "watch": "devicescript devtools --watch",
+                                        "start": "yarn watch",
                                     },
                                 },
                             },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -143,7 +143,7 @@ async function createConfig() {
                                     scripts: {
                                         "setup": "devicescript init",
                                         "build": "devicescript build",
-                                        "watch": "devicescript devtools --watch",
+                                        "watch": "devicescript devtools main.ts",
                                         "start": "yarn watch",
                                     },
                                 },


### PR DESCRIPTION
Use devtools instead of build --watch.

@mmoskal should we ask for a filename to turn on watch?