### PR TITLE
fix: use vscode built-in file system watcher

### DIFF
--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -264,8 +264,6 @@ export class DeviceScriptConfigurationProvider
             )
             return undefined
         }
-        // update watch
-        await this.extensionState.devtools.watch(program, service)
         // save as currently debugged project
         await this.extensionState.updateCurrentDeviceScriptManagerId(
             service.device.deviceId

--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -174,8 +174,9 @@ export class DeviceScriptConfigurationProvider
     ) {
         const sessionConfig = config as vscode.DebugSessionOptions
         const dsConfig = config as StartArgs
+        const { program } = config
 
-        if (!config.program) {
+        if (!program) {
             vscode.window.showErrorMessage(
                 "DeviceScript: Debug cancelled. Cannot find a program to debug."
             )
@@ -254,11 +255,8 @@ export class DeviceScriptConfigurationProvider
 
         // build and deploy
         const buildResult = await this.extensionState.devtools.build(
-            config.program,
-            {
-                service,
-                watch: true,
-            }
+            program,
+            service
         )
         if (!buildResult?.success) {
             vscode.window.showErrorMessage(
@@ -266,6 +264,8 @@ export class DeviceScriptConfigurationProvider
             )
             return undefined
         }
+        // update watch
+        await this.extensionState.devtools.watch(program, service)
         // save as currently debugged project
         await this.extensionState.updateCurrentDeviceScriptManagerId(
             service.device.deviceId

--- a/vscode/src/devtoolsserver.ts
+++ b/vscode/src/devtoolsserver.ts
@@ -219,10 +219,9 @@ export class DeveloperToolsManager extends JDEventSource {
 
     private async startWatch() {
         const filename = this._currentFilename
-        const service = this._currentDeviceScriptManager
+        const sid = this._currentDeviceScriptManager
 
         console.debug(`fs.watch: ${filename}`)
-        const sid = service?.id
         const handleChange = async (uri: vscode.Uri) => {
             console.debug(`fs changed: ${uri.fsPath}`)
             const service = this.extensionState.bus.node(sid) as JDService

--- a/vscode/src/mainstatusbar.ts
+++ b/vscode/src/mainstatusbar.ts
@@ -1,4 +1,4 @@
-import { CHANGE, ConnectionState } from "jacdac-ts"
+import { CHANGE, ConnectionState, JDService } from "jacdac-ts"
 import * as vscode from "vscode"
 import { toMarkdownString } from "./catalog"
 import { Utils } from "vscode-uri"
@@ -27,6 +27,9 @@ export function activateMainStatusBar(
             currentFilename,
             currentDeviceScriptManager,
         } = extensionState.devtools
+        const deviceScriptManager = bus.node(
+            currentDeviceScriptManager
+        ) as JDService
         const connected = connectionState === ConnectionState.Connected
         const devices = bus.devices({
             ignoreInfrastructure: true,
@@ -73,7 +76,7 @@ ${
           )})`
         : ""
 } - entry point file<br/>
-${currentDeviceScriptManager?.qualifiedName || "..."} - deploy to device</br>
+${deviceScriptManager?.qualifiedName || "..."} - deploy to device</br>
 `)
         statusBarItem.text = [
             connectionState === ConnectionState.Connected

--- a/vscode/src/mainstatusbar.ts
+++ b/vscode/src/mainstatusbar.ts
@@ -24,6 +24,8 @@ export function activateMainStatusBar(
             nodeVersion,
             version,
             projectFolder,
+            currentFilename,
+            currentDeviceScriptManager,
         } = extensionState.devtools
         const connected = connectionState === ConnectionState.Connected
         const devices = bus.devices({
@@ -55,15 +57,23 @@ ${nodeVersion?.slice(1) || "?"} - node version<br/>
 
 ---
 
-project: ${
-                  projectFolder
-                      ? `[${Utils.basename(projectFolder)}](${Utils.joinPath(
-                            projectFolder,
-                            "devsconfig.json"
-                        )})`
-                      : ""
-              }
-
+${
+    projectFolder
+        ? `[${Utils.basename(projectFolder)}](${Utils.joinPath(
+              projectFolder,
+              "devsconfig.json"
+          )})`
+        : ""
+} - project<br/>
+${
+    projectFolder && currentFilename
+        ? `[${currentFilename}](${Utils.joinPath(
+              projectFolder,
+              currentFilename
+          )})`
+        : ""
+} - entry point file<br/>
+${currentDeviceScriptManager?.qualifiedName || "..."} - deploy to device</br>
 `)
         statusBarItem.text = [
             connectionState === ConnectionState.Connected

--- a/vscode/src/state.ts
+++ b/vscode/src/state.ts
@@ -74,7 +74,7 @@ export class DeviceScriptExtensionState extends JDEventSource {
         this.bus.on([DEVICE_CHANGE, CONNECTION_STATE], () => {
             this.emit(CHANGE)
         })
-
+        this.devtools.on(CHANGE, () => this.emit(CHANGE))
         subSideEvent<SideTransportEvent>("transport", msg => {
             const _transport = msg.data
             if (


### PR DESCRIPTION
vscode has builtin support to spin off file system watchers, using instead of native cli watchers.