### PR TITLE
docs: fix broken HomeBridge hyperlink

### DIFF
--- a/website/docs/getting-started/samples/homebridge-humidity.mdx
+++ b/website/docs/getting-started/samples/homebridge-humidity.mdx
@@ -45,7 +45,7 @@ You will need the URL, port and optionaly username, password to configure the ga
 
 ## HomeBridge configuration
 
--   Install [HomeBridge](https://homebridge)
+-   Install [HomeBridge](https://homebridge.io/)
 -   Open the plugins pane and install the [HomeBridge MQTTThing plugin](https://www.npmjs.com/package/homebridge-mqttthing) plugin
 -   Click on `SETTINGS` for the MQTTThing plugin and add a **Humidity Sensor** accessory
 -   Configure the MQTT settings to connect to the MQTT server


### PR DESCRIPTION
The PR contains a simple fix to the HomeBridge broken hyperlink found in the docs.