### PR TITLE
tsdoc attributes normalization

### DIFF
--- a/compiler/src/compiler.ts
+++ b/compiler/src/compiler.ts
@@ -107,6 +107,7 @@ export const TSDOC_PART = "devsPart"
 export const TSDOC_SERVICES = "devsServices"
 export const TSDOC_START = "devsStart"
 export const TSDOC_GPIO = "devsGPIO"
+export const TSDOC_WHEN_USED = "devsWhenUsed"
 
 const coreModule = "@devicescript/core"
 
@@ -531,7 +532,7 @@ interface PossiblyConstDeclaration extends ts.Declaration {
     __ds_const_val?: Folded
 }
 
-export function getSymTags(sym: ts.Symbol, pref = "ds-") {
+export function getSymTags(sym: ts.Symbol, pref = "devs") {
     const tags: Record<string, string> = {}
     for (const tag of sym?.getJsDocTags() ?? []) {
         if (tag.name.startsWith(pref)) {
@@ -895,7 +896,7 @@ class Program implements TopOpWriter {
         }
 
         const tags = getSymTags(this.getSymAtLocation(node))
-        const gpio = parseInt(tags["ds-gpio"])
+        const gpio = parseInt(tags[TSDOC_GPIO])
         if (!isNaN(gpio)) return gpio
 
         throwError(node, `expecting JSON literal here`)
@@ -1821,7 +1822,7 @@ class Program implements TopOpWriter {
         const fdecl = this.getCellAtLocation(stmt) as FunctionDecl
         assert(fdecl instanceof FunctionDecl)
         const classTags = getSymTags(this.getSymAtLocation(stmt))
-        const whenUsed = classTags["ds-when-used"] !== undefined
+        const whenUsed = classTags[TSDOC_WHEN_USED] !== undefined
 
         let numCtorArgs: number = null
 
@@ -1847,7 +1848,7 @@ class Program implements TopOpWriter {
                 }
                 if (info.methodName == "toString") this.toStringError(mem)
                 this.protoDefinitions.push(info)
-                if (whenUsed || tags["ds-when-used"] !== undefined) {
+                if (whenUsed || tags[TSDOC_WHEN_USED] !== undefined) {
                     // skip marking as used
                 } else {
                     this.markMethodUsed(info.names[0])
@@ -2797,7 +2798,7 @@ class Program implements TopOpWriter {
 
     private emitBuiltInConst(expr: ts.Expression) {
         const tags = getSymTags(this.getSymAtLocation(expr))
-        const gpio = parseInt(tags["ds-gpio"])
+        const gpio = parseInt(tags[TSDOC_GPIO])
         if (!isNaN(gpio)) {
             const wr = this.writer
             wr.emitCall(this.dsMember("gpio"), literal(gpio))

--- a/compiler/src/compiler.ts
+++ b/compiler/src/compiler.ts
@@ -103,6 +103,9 @@ export const DEVS_LIB_FILE = `${DEVS_FILE_PREFIX}-lib.json`
 export const DEVS_DBG_FILE = `${DEVS_FILE_PREFIX}-dbg.json`
 export const DEVS_SIZES_FILE = `${DEVS_FILE_PREFIX}-sizes.md`
 
+export const TSDOC_PART = "devsPart"
+export const TSDOC_SERVICES = "devsServices"
+
 const coreModule = "@devicescript/core"
 
 const globalFunctions = [

--- a/compiler/src/compiler.ts
+++ b/compiler/src/compiler.ts
@@ -106,6 +106,7 @@ export const DEVS_SIZES_FILE = `${DEVS_FILE_PREFIX}-sizes.md`
 export const TSDOC_PART = "devsPart"
 export const TSDOC_SERVICES = "devsServices"
 export const TSDOC_START = "devsStart"
+export const TSDOC_GPIO = "devsGPIO"
 
 const coreModule = "@devicescript/core"
 

--- a/compiler/src/compiler.ts
+++ b/compiler/src/compiler.ts
@@ -105,6 +105,7 @@ export const DEVS_SIZES_FILE = `${DEVS_FILE_PREFIX}-sizes.md`
 
 export const TSDOC_PART = "devsPart"
 export const TSDOC_SERVICES = "devsServices"
+export const TSDOC_START = "devsStart"
 
 const coreModule = "@devicescript/core"
 
@@ -927,7 +928,7 @@ class Program implements TopOpWriter {
         if (!nn) return undefined
 
         const tags = getSymTags(sym)
-        const dsstart = tags["ds-start"]
+        const dsstart = tags[TSDOC_START]
         if (dsstart) {
             let sinfo: BaseServiceConfig
             try {
@@ -943,7 +944,7 @@ class Program implements TopOpWriter {
                     sinfo.name = str
                 }
                 return this.startServer(expr, sinfo)
-            } else throwError(expr, "invalid @ds-start tag")
+            } else throwError(expr, `invalid @${TSDOC_START} tag`)
         }
 
         if (nn.startsWith(startServerPref)) {

--- a/compiler/src/serverinfo.ts
+++ b/compiler/src/serverinfo.ts
@@ -4,7 +4,7 @@ import { Host } from "./format"
 import { preludeFiles } from "./specgen"
 import { camelize, upperCamel } from "./util"
 import { ServerInfoFile } from "@devicescript/interop"
-import { getSymTags } from "./compiler"
+import { TSDOC_PART, TSDOC_SERVICES, getSymTags } from "./compiler"
 
 export function serverInfo(host: Host) {
     const { program } = buildAST(
@@ -42,9 +42,9 @@ export function serverInfo(host: Host) {
     function customServer(stmt: ts.FunctionDeclaration) {
         const sym = checker.getSymbolAtLocation(stmt.name)
         const tags = getSymTags(sym, "")
-        if (!tags["ds-part"]) return
+        if (!tags[TSDOC_PART]) return
 
-        const serv = (tags?.["ds-services"] ?? "")
+        const serv = (tags?.[TSDOC_SERVICES] ?? "")
             .split(/[,;\s]+/)
             .filter(Boolean)
             .map(servName => {
@@ -91,7 +91,7 @@ export function serverInfo(host: Host) {
         const snippet = `const ${varName} = ${isAwait}${sym.name}()\n`
 
         info.servers.push({
-            label: tags["ds-part"] ?? sym.name.slice("start".length),
+            label: tags[TSDOC_PART] ?? sym.name.slice("start".length),
             detail,
             startName: sym.name,
             classIdentifiers: serv.length

--- a/compiler/src/specgen.ts
+++ b/compiler/src/specgen.ts
@@ -32,7 +32,7 @@ import { prelude } from "./prelude"
 import { camelize, oops, upperCamel, upperFirst } from "./util"
 import { pinFunctions } from "./board"
 import { assert } from "./jdutil"
-import { TSDOC_START } from "./compiler"
+import { TSDOC_GPIO, TSDOC_START } from "./compiler"
 
 const REGISTER_NUMBER = "Register<number>"
 const REGISTER_BOOL = "Register<boolean>"
@@ -321,7 +321,7 @@ function boardFile(binfo: DeviceConfig, arch: ArchConfig) {
                 `/**`,
                 ` * Pin ${pinName} (GPIO${gpio}, ${funs.join(", ")})`,
                 ` *`,
-                ` * @ds-gpio ${gpio}`,
+                ` * @${TSDOC_GPIO} ${gpio}`,
                 ` */`,
                 // `//% gpio=${gpio}`,
                 `${pinName}: ${types.join(" & ")}`,

--- a/compiler/src/specgen.ts
+++ b/compiler/src/specgen.ts
@@ -32,6 +32,7 @@ import { prelude } from "./prelude"
 import { camelize, oops, upperCamel, upperFirst } from "./util"
 import { pinFunctions } from "./board"
 import { assert } from "./jdutil"
+import { TSDOC_START } from "./compiler"
 
 const REGISTER_NUMBER = "Register<number>"
 const REGISTER_BOOL = "Register<boolean>"
@@ -297,7 +298,7 @@ function boardFile(binfo: DeviceConfig, arch: ArchConfig) {
         const inst = service.name ? upperFirst(service.name) : serv
         r += wrapComment(
             "devs",
-            `Start built-in ${inst}\n@ds-start ${JSON.stringify(service)}`
+            `Start built-in ${inst}\n@${TSDOC_START} ${JSON.stringify(service)}`
         )
         r += `        start${inst}(roleName?: string): ds.${serv}\n`
     }

--- a/devs/run-tests/basic.ts
+++ b/devs/run-tests/basic.ts
@@ -1027,7 +1027,7 @@ function testStatic() {
 /**
  * Foo
  *
- * @ds-when-used
+ * @devsWhenUsed
  */
 class Foo2 {
     meth1() {}

--- a/packages/drivers/src/aht20.ts
+++ b/packages/drivers/src/aht20.ts
@@ -50,8 +50,8 @@ class AHT20Driver extends I2CSensorDriver<{
 
 /**
  * Start driver for AHT20 temperature/humidity sensor at I2C address `0x38`.
- * @ds-part AHT20
- * @ds-services temperature, humidity
+ * @devsPart AHT20
+ * @devsServices temperature, humidity
  * @see {@link https://asairsensors.com/wp-content/uploads/2021/09/Data-Sheet-AHT20-Humidity-and-Temperature-Sensor-ASAIR-V1.0.03.pdf | Datasheet}.
  * @throws DriverError
  */

--- a/packages/drivers/src/bme680.ts
+++ b/packages/drivers/src/bme680.ts
@@ -313,8 +313,8 @@ class BME680Driver extends I2CSensorDriver<{
  * Start driver for Bosch BME680 temperature/humidity/pressure/gas sensor at I2C `0x76` (default) or `0x77`.
  * @see {@link https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme680-ds001.pdf | Datasheet}
  * @see {@link https://www.adafruit.com/product/3660 | Adafruit}
- * @ds-part Bosch BME68
- * @ds-services temperature, humidity, airPressure, airQualityIndex
+ * @devsPart Bosch BME68
+ * @devsServices temperature, humidity, airPressure, airQualityIndex
  * @throws DriverError
  */
 export async function startBME680(options?: {

--- a/packages/drivers/src/ltr390.ts
+++ b/packages/drivers/src/ltr390.ts
@@ -57,8 +57,8 @@ class LTR390Driver extends I2CSensorDriver<{
 
 /**
  * Start driver for LITEON LTR-390UV-01 UV/ambient light sensor at I2C address `0x53`.
- * @ds-part LITEON LTR-390UV-01
- * @ds-services uvIndex, illuminance
+ * @devsPart LITEON LTR-390UV-01
+ * @devsServices uvIndex, illuminance
  * @see {@link https://optoelectronics.liteon.com/upload/download/DS86-2015-0004/LTR-390UV_Final_%20DS_V1%201.pdf | Datasheet}
  * @throws DriverError
  */

--- a/packages/drivers/src/sht30.ts
+++ b/packages/drivers/src/sht30.ts
@@ -31,8 +31,8 @@ class SHT30Driver extends SHTDriver {
 
 /**
  * Start driver for Sensirion SHT30 temperature/humidity sensor at I2C `0x44` or `0x45` (default is `0x44`)
- * @ds-part Sensirion SHT30
- * @ds-services temperature, humidity
+ * @devsPart Sensirion SHT30
+ * @devsServices temperature, humidity
  * @see {@link https://sensirion.com/products/catalog/SHT30-DIS-B/ | Datasheet}
  * @throws DriverError
  */

--- a/packages/drivers/src/shtc3.ts
+++ b/packages/drivers/src/shtc3.ts
@@ -55,8 +55,8 @@ class SHTC3Driver extends SHTDriver {
 
 /**
  * Start driver for Sensirion SHTC3 temperature/humidity sensor at I2C `0x70`.
- * @ds-part Sensirion SHTC3
- * @ds-services temperature, humidity
+ * @devsPart Sensirion SHTC3
+ * @devsServices temperature, humidity
  * @see {@link https://sensirion.com/products/catalog/SHTC3/ | Datasheet}
  * @throws DriverError
  */

--- a/website/docs/language/tree-shaking.mdx
+++ b/website/docs/language/tree-shaking.mdx
@@ -11,7 +11,7 @@ keywords:
 ---
 # Tree-shaking
 
-Classes and/or methods in classes can be marked with `@ds-when-used` JSDoc attribute.
+Classes and/or methods in classes can be marked with `@devsWhenUsed` JSDoc attribute.
 This will cause them to be omitted from compilation unless they are used.
 In such case, care needs to be taken when using index operator (`obj[some_expression]`)
 or accessing properties through `any` type.
@@ -21,7 +21,7 @@ You can use `ds.keep()` function to make sure methods are included.
 /**
  * Foooooo!
  * 
- * @ds-when-used
+ * @devsWhenUsed
  */
 class Foo {
     bar() {}
@@ -35,7 +35,7 @@ callBar(new Foo())
 ds.keep(Foo.prototype.bar)
 ```
 
-The `@ds-when-used` attribute is implicit when methods are defined through
+The `@devsWhenUsed` attribute is implicit when methods are defined through
 prototype assignments.
 
 We may improve compiler warnings about such cases in future.


### PR DESCRIPTION
Turns out that VSCode really wants camelized names to colorize the jsdoc attributes.