### PR TITLE
added socket example, use same api as node

### DIFF
--- a/packages/net/src/fetch.ts
+++ b/packages/net/src/fetch.ts
@@ -1,4 +1,4 @@
-import { Socket, SocketProto } from "./sockets"
+import { Socket, SocketProto, connect } from "./sockets"
 
 export interface FetchOptions {
     method?:
@@ -161,7 +161,7 @@ export async function fetch(url: string, options?: FetchOptions) {
     if (bodyLen) hd.set("content-length", bodyLen + "")
 
     const reqStr = `${options.method} ${path} HTTP/1.1\r\n${hd.serialize()}\r\n`
-    const s = await Socket.connect({
+    const s = await connect({
         host,
         port,
         proto,

--- a/packages/net/src/fetch.ts
+++ b/packages/net/src/fetch.ts
@@ -1,5 +1,8 @@
 import { Socket, SocketProto, connect } from "./sockets"
 
+/**
+ * Represents options for a fetch request.
+ */
 export interface FetchOptions {
     method?:
         | "GET"
@@ -105,7 +108,19 @@ export class Response {
     }
 }
 
-export async function fetch(url: string, options?: FetchOptions) {
+/**
+ * Fetches a resource from the network.
+ *
+ * @param url - The URL to fetch.
+ * @param options - Optional fetch options.
+ * @returns A promise that resolves to a `Response` object.
+ *
+ * @throws {TypeError} If the URL is invalid or the request body is not a string or buffer.
+ */
+export async function fetch(
+    url: string,
+    options?: FetchOptions
+): Promise<Response> {
     if (!options) options = {}
     if (!options.method) options.method = "GET"
     if (!options.headers) options.headers = new Headers()

--- a/packages/net/src/sockets.ts
+++ b/packages/net/src/sockets.ts
@@ -12,6 +12,13 @@ let socket: Socket
 
 export type SocketProto = "tcp" | "tls"
 
+export interface SocketConnectOptions {
+    host: string
+    port: number
+    proto?: SocketProto
+    timeout?: number
+}
+
 export class Socket {
     private buffers: Buffer[] = []
     private lastError: Error
@@ -122,16 +129,7 @@ export class Socket {
         }
     }
 
-    /**
-     * Create a new socket and connect it.
-     * Throws on error or timeout.
-     */
-    static async connect(options: {
-        host: string
-        port: number
-        proto?: SocketProto
-        timeout?: number
-    }) {
+    static async _connect(options: SocketConnectOptions) {
         let { host, port, proto } = options
         if (!proto) proto = "tcp"
         const port2 = proto === "tls" ? -port : port
@@ -153,4 +151,13 @@ export class Socket {
         ds.assert(v === true)
         return socket
     }
+}
+
+/**
+ * Create a new socket and connect it.
+ * Throws on error or timeout.
+ * @param options socket connection options
+ */
+export async function connect(options: SocketConnectOptions) {
+    return await Socket._connect(options)
 }

--- a/packages/sampleprj/src/mainsockets.ts
+++ b/packages/sampleprj/src/mainsockets.ts
@@ -1,0 +1,21 @@
+import { connect, fetch } from "@devicescript/net"
+
+// fetch
+console.log(`using fetch...`)
+const res = await fetch("https://github.com/status.json")
+const json = await res.json()
+console.log(json)
+
+// socket
+console.log(`using socket...`)
+const socket = await connect({ proto: "tls", host: "github.com", port: 443 })
+await socket.send(`GET /status.json HTTP/1.1
+user-agent: DeviceScript fetch()
+accept: */*
+host: github.com
+connection: close
+
+`)
+const status = await socket.readLine()
+console.log(status)
+await socket.close()

--- a/website/docs/developer/net.mdx
+++ b/website/docs/developer/net.mdx
@@ -1,9 +1,9 @@
 ---
-title: TCP/TLS Sockets
+title: net
 sidebar_position: 14
 ---
 
-# TCP/TLS Sockets
+# net
 
 ## fetch
 
@@ -25,7 +25,7 @@ can help you with understanding how to use sockets.
 
 :::
 
-## Sockets
+## TCP/TLS Sockets
 
 Use `net.connect` to open a socket TCP or TLS socket.
 

--- a/website/docs/developer/net.mdx
+++ b/website/docs/developer/net.mdx
@@ -7,7 +7,7 @@ sidebar_position: 14
 
 ## fetch
 
-DeviceScript provides the familiar `fetch` function to issue HTTP requests.
+DeviceScript provides the familiar `fetch` function to issue HTTP/HTTPS requests.
 `fetch` is designed to match the browser [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
 ```ts

--- a/website/docs/developer/net.mdx
+++ b/website/docs/developer/net.mdx
@@ -24,3 +24,25 @@ The [fetch sources](https://github.com/microsoft/devicescript/blob/main/packages
 can help you with understanding how to use sockets.
 
 :::
+
+## Sockets
+
+Use `net.connect` to open a socket TCP or TLS socket.
+
+This example issues is HTTPS request to the Github.com status API.
+
+```ts
+import { connect } from "@devicescript/net"
+
+const socket = await connect({ proto: "tls", host: "github.com", port: 443 })
+await socket.send(`GET /status.json HTTP/1.1
+user-agent: DeviceScript fetch()
+accept: */*
+host: github.com
+connection: close
+
+`)
+const status = await socket.readLine()
+console.log(status)
+await socket.close()
+```


### PR DESCRIPTION
Better docs on sockets
move Socket.connect to just "connect" to match node.