### PR TITLE
support for typedoc ready projects

### DIFF
--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -31,6 +31,7 @@ import type {
 import { addBoard } from "./addboard"
 import { readJSON5Sync } from "./jsonc"
 import { MIN_NODE_VERSION } from "@devicescript/interop"
+import { TSDOC_TAGS } from "@devicescript/compiler"
 
 const MAIN = "src/main.ts"
 const GITIGNORE = ".gitignore"
@@ -68,8 +69,23 @@ const npmFiles: FileSet = {
         },
         files: ["src/*.ts", "devsconfig.json"],
         keywords: ["devicescript"],
+        scripts: {
+            "build:docs":
+                "npx typedoc ./src/index.ts --tsconfig ./src/tsconfig.json",
+        },
     },
     "src/index.ts": `${IMPORT_PREFIX}\n\n`,
+    "src/tsdoc.json": {
+        [IS_PATCH]: true,
+        $schema:
+            "https://developer.microsoft.com/en-us/json-schemas/tsdoc/v0/tsdoc.schema.json",
+        extends: ["typedoc/tsdoc.json"],
+        noStandardTags: false,
+        tagDefinitions: TSDOC_TAGS.map(tag => ({
+            tagName: `@${tag}`,
+            syntaxKind: "modifier",
+        })),
+    },
     ".github/workflows/build.yml": `name: Build
 
 on:
@@ -88,7 +104,7 @@ jobs:
                   node-version: ${MIN_NODE_VERSION}
             - run: npm ci
             - run: npm run build
-            - run: npm test    
+            - run: npm test
 `,
 }
 

--- a/compiler/src/compiler.ts
+++ b/compiler/src/compiler.ts
@@ -111,6 +111,14 @@ export const TSDOC_START = "devsStart"
 export const TSDOC_WHEN_USED = "devsWhenUsed"
 export const TSDOC_NATIVE = "devsNative"
 
+export const TSDOC_TAGS = [
+    TSDOC_PART,
+    TSDOC_SERVICES,
+    TSDOC_START,
+    TSDOC_WHEN_USED,
+    TSDOC_NATIVE,
+]
+
 const coreModule = "@devicescript/core"
 
 const globalFunctions = [

--- a/website/docs/developer/packages/custom.mdx
+++ b/website/docs/developer/packages/custom.mdx
@@ -53,6 +53,18 @@ npm install --save user/repo@version
 
 :::
 
+## TypeDoc
+
+The package templates also adds a script `build:docs` to generate an API documentation
+site using [TypeDoc](https://typedoc.org/).
+The [devicescript-pico-bricks](https://pelikhan.github.io/devicescript-pico-bricks) is an example of this web site.
+
+```bash npm2yarn
+npm run build:docs
+```
+
+You can configure GitHub pages to use the generated site under `./docs`.
+
 ## Development notes
 
 Note that regular DeviceScript applications typically use `src/main.ts` (or `src/mainSomething.ts`)


### PR DESCRIPTION
When adding npm to a package, drop files to enable proper generation of TypeDoc web site.

- example: https://pelikhan.github.io/devicescript-pico-bricks