### PR TITLE
project init (create new project) with board

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -341,6 +341,7 @@ export async function mainCli() {
 
     addCommand("init", program)
         .argument("[dir]", "path to create or update project", "./")
+        .option("-b, --board <board-id>", "board ID")
         .description("creates or configures a devicescript project")
         .action(dropReturn(init))
 

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -365,6 +365,7 @@ export interface InitOptions {
     force?: boolean
     spaces?: number
     install?: boolean
+    board?: string
 }
 
 function patchJSON(fn: string, data: any) {
@@ -451,9 +452,10 @@ function finishAdd(message: string, files: string[] = []) {
 export async function init(dir: string | undefined, options: InitOptions) {
     log(`Configuring DeviceScript project`)
 
+    // write template files
     const cwd = writeFiles(dir, options, optionalFiles)
 
-    // .gitignore
+    // patch .gitignore
     const gids = ["node_modules", GENDIR, ".env.local", ".env.*.local"]
     const gitignoren = join(cwd, GITIGNORE)
     if (!pathExistsSync(gitignoren)) {
@@ -479,6 +481,19 @@ export async function init(dir: string | undefined, options: InitOptions) {
     }
 
     await runInstall(cwd, options)
+
+    // patch main.ts with board info
+    if (options.board) {
+        const mainFn = join(cwd, MAIN)
+        if (pathExistsSync(mainFn)) {
+            const main = readFileSync(mainFn, { encoding: "utf8" })
+            if (!main.includes(`from "@dsboard/${options.board}"`)) {
+                const importStmt = `import { pins, board } from "@dsboard/${options.board}"\n`
+                const newMain = importStmt + main
+                writeFileSync(mainFn, newMain, { encoding: "utf8" })
+            }
+        }
+    }
 
     // build to get node_modules/@devicescript/* files etc
     await build(MAIN, {})

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -255,11 +255,6 @@ const optionalFiles: FileSet = {
         recommendations: [
             "devicescript.devicescript-vscode",
             "esbenp.prettier-vscode",
-            "ms-toolsai.jupyter",
-            "ms-toolsai.jupyter-renderers",
-            "ms-python.python",
-            "ms-python.vscode-pylance",
-            "mechatroner.rainbow-csv",
         ],
     },
     ".vscode/launch.json": {

--- a/vscode/src/activateDeviceScript.ts
+++ b/vscode/src/activateDeviceScript.ts
@@ -74,6 +74,13 @@ export function activateDeviceScript(context: vscode.ExtensionContext) {
                     })
                     if (projectName === undefined) return
                 }
+
+                const board = await extensionState.showQuickPickBoard(
+                    "Pick a board for your project",
+                    { useUniqueDevice: true }
+                )
+                if (board === undefined) return
+
                 const cwd = projectName
                     ? Utils.joinPath(folder, projectName)
                     : folder
@@ -82,9 +89,9 @@ export function activateDeviceScript(context: vscode.ExtensionContext) {
                     isTransient: true,
                     cwd,
                 })
-                terminal.sendText(
-                    "npx --yes @devicescript/cli@latest init --quiet"
-                )
+                let cmd = "npx --yes @devicescript/cli@latest init --quiet"
+                if (board) cmd += ` --board ${board.id}`
+                terminal.sendText(cmd)
                 terminal.show()
 
                 if (askOpen) {

--- a/vscode/src/pickers.ts
+++ b/vscode/src/pickers.ts
@@ -1,7 +1,4 @@
-import type { DeviceConfig } from "@devicescript/interop"
 import * as vscode from "vscode"
-import { Utils } from "vscode-uri"
-import { openDocUri } from "./commands"
 
 export type TaggedQuickPickItem<T> = vscode.QuickPickItem & { data?: T }
 

--- a/vscode/src/state.ts
+++ b/vscode/src/state.ts
@@ -356,7 +356,7 @@ export class DeviceScriptExtensionState extends JDEventSource {
                 matchOnDescription: true,
             }
         )
-        if (!res) return // user escaped
+        if (!res) return undefined // user escaped
 
         if (!res.data?.board) {
             openDocUri("devices")

--- a/website/docs/api/cli.mdx
+++ b/website/docs/api/cli.mdx
@@ -61,6 +61,11 @@ devs init --force
 
 Do not run `npm` or `yarn ` install after dropping the files.
 
+### --board board-id
+
+Specify the device identifier to use for the project.
+The generate will patch `./src/main.ts` and insert the board import statement.
+
 ## devs add ...
 
 The generated project by `init` is barebone by design. The `add` command can be used to

--- a/website/docs/developer/console.mdx
+++ b/website/docs/developer/console.mdx
@@ -1,14 +1,15 @@
 ---
 sidebar_position: 1
 description: Learn how to use console functionality in DeviceScript to add
-  logging to your script and how to use format strings to write registers.
+    logging to your script and how to use format strings to write registers.
 keywords:
-  - DeviceScript
-  - console
-  - logging
-  - format strings
-  - registers
+    - DeviceScript
+    - console
+    - logging
+    - format strings
+    - registers
 ---
+
 # Console output
 
 DeviceScript supports basic `console` functionality which allows you to add logging to your script.
@@ -33,9 +34,18 @@ const humi = 60
 console.data({ temp, humi })
 ```
 
-In Visual Studio Code, you will find the data in the **DeviceScript - Data** output pane or you can download it from the view menu.
+In Visual Studio Code, you will find the data in the **DeviceScript - Data**
+output pane or you can download it from the view menu.
 
 ![console data icon](./consoledata.png)
+
+The following Visual Studio Code extensions are recommended for a best experience:
+
+-   [Jupyter](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter)
+-   [Jupyter Renderers](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter-renderers)
+-   [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
+-   [PyLance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)
+-   [Raibow CSV](https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv)
 
 ## Format strings
 


### PR DESCRIPTION
Add choosing board id in "create new project" flow to avoid missing the pin configuration step.

- also reduce number of recommended extensions