### PR TITLE
Update node version warning in devtoolsserver.ts

### DIFF
--- a/vscode/src/devtoolsserver.ts
+++ b/vscode/src/devtoolsserver.ts
@@ -890,7 +890,7 @@ export class DeveloperToolsManager extends JDEventSource {
             if (!(v.major >= MIN_NODE_VERSION)) {
                 showErrorMessage(
                     "terminal.nodeversion",
-                    `Node.JS version outdated, found ${v.major}.${v.minor} but needed v16+.`
+                    `Node.JS version outdated, found ${v.major}.${v.minor} but needed v${MIN_NODE_VERSION}+.`
                 )
                 return undefined
             }


### PR DESCRIPTION
The warning says 16+ is required, when actually 20+ is required. I had 18 and was very confused with the warning until I looked at the source code.