### PR TITLE
Update docs on required node version

### DIFF
--- a/website/docs/getting-started/vscode/index.mdx
+++ b/website/docs/getting-started/vscode/index.mdx
@@ -12,7 +12,7 @@ The [Visual Studio Code](https://code.visualstudio.com/) extension provides the 
 
 You will also need
 
--   **[Node.JS 16+](https://nodejs.org/en/download/)**
+-   **[Node.JS 20+](https://nodejs.org/en/download/)**
 -   **[Visual Studio Code](https://code.visualstudio.com/)**
 
 <StaticVideo name="blinky" />


### PR DESCRIPTION
20+ is actually required, not 16. I also updated the warning in code with this other PR: https://github.com/microsoft/devicescript/pull/680