### PR TITLE
Removed unnecessary use of node to run a bash script

### DIFF
--- a/vscode/src/devtoolsserver.ts
+++ b/vscode/src/devtoolsserver.ts
@@ -927,6 +927,7 @@ export class DeveloperToolsManager extends JDEventSource {
                     "devicescript.jacdac"
                 )
                 const isWindows = globalThis.process?.platform === "win32"
+                const isLinux = globalThis.process?.platform === "linux"
                 const useShell =
                     this.lastCreateCliFailed ||
                     (options.useShell ?? !!devToolsConfig.get("shell"))
@@ -939,6 +940,9 @@ export class DeveloperToolsManager extends JDEventSource {
                 const internet =
                     options.internet || !!devToolsConfig.get("internet")
                 let cli = nodePath || "node"
+                if(isLinux) {
+                    cli = "";
+                }
                 if (isWindows) {
                     cli = "node_modules\\.bin\\devicescript.cmd"
                 } else args.unshift("./node_modules/.bin/devicescript")


### PR DESCRIPTION
Hello
This PR is only to remove an unnecessary use of node to run a bash script.

In Linux the extension is trying to run the development Server using the Node runtime, but the file chosen is written in Bash script.
Since I don't own any Windows Device to test (for now), I just removed the use of Node for Linux